### PR TITLE
Fixing condition that breaks when dealing with empty nodes

### DIFF
--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -151,7 +151,7 @@ export class Converter {
         const converted_texts: Text[] = [];
         this.log.info(`Found ${texts.length} text(s)`);
         for (const text of texts) {
-            if (text.children[0].innerHTML) {
+            if (text.children[0]?.innerHTML) {
                 const textBoundaries = text.getBoundingClientRect();
 
                 const converted_text = new Text();


### PR DESCRIPTION
Hi!
This is a quick fix for when a page contains some math equations and the extension breaks trying to deal with empty nodes around them. Here is an example piece of HTML that caused errors:

```html
<span data-contrast="auto" class="TextRun EmptyTextRun" xml:lang="X-NONE" lang="X-NONE" style="color: windowtext; font-size: 11pt; font-family: WordVisi_MSFontService, Calibri, sans-serif; line-height: 17px;"></span>
<span class="MathEquationContainer BlobObject DragDrop" contenteditable="false" style="font-size: 11pt; line-height: normal;"><span class="EquationPlaceholderText" style="display: none;">[Equation]</span><span class="RawEquation" data-length="6" style="display: none;">﷐𝑎﷯𝑏</span><span class="MathSpan" style="display: inline-block; background-color: inherit;"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mover accent="true"><mi>a</mi><mo>-</mo></mover><mi>b</mi></math></span></span>
```

The `span.TextRun` above doesn't have any children. I am not sure when and how those "empty text runs" are introduced but they're usually next to the math equations in my notes, so I am assuming that's what causing them.

There are several ways on how this could have been done. One would be to change the querying code to:
```js
const texts = document.querySelectorAll("span.TextRun:not(.EmptyTextRun)"); // or maybe even :not(:empty)
```
But I've decided to just modify the `if` statement.