### PR TITLE
MathML support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,9 @@
   "exportTextsLabel": {
     "message": "Export texts"
   },
+  "exportMathLabel": {
+    "message": "Export math"
+  },
   "exportSeparateLayersLabel": {
     "message": "Export in separate layers"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -43,5 +43,17 @@
   },
   "reportIssueText": {
     "message": "Report an issue"
+  },
+  "mathQualityLabel": {
+    "message": "Math export quality"
+  },
+  "mathLowQuality": {
+    "message": "Low"
+  },
+  "mathMediumQuality": {
+    "message": "Medium"
+  },
+  "mathHighQuality": {
+    "message": "High"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -43,5 +43,17 @@
   },
   "reportIssueText": {
     "message": "Segnala un problema"
+  },
+  "mathQualityLabel": {
+    "message": "Qualità esport. matematica"
+  },
+  "mathLowQuality": {
+    "message": "Bassa"
+  },
+  "mathMediumQuality": {
+    "message": "Media"
+  },
+  "mathHighQuality": {
+    "message": "Alta"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -23,6 +23,9 @@
   "exportTextsLabel": {
     "message": "Esporta testi"
   },
+  "exportMathLabel": {
+    "message": "Esporta matematica"
+  },
   "exportSeparateLayersLabel": {
     "message": "Esporta in layer separati"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/webextension-polyfill": "^0.10.7",
         "esbuild": "^0.21.5",
         "html-minifier-terser": "^7.2.0",
+        "mathjax-full": "4.0.0-beta.5",
         "mathml-to-latex": "^1.4.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.5.2",
@@ -4157,6 +4158,24 @@
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "dev": true
     },
+    "node_modules/mathjax-full": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-4.0.0-beta.5.tgz",
+      "integrity": "sha512-jip3uG5u9rchnELY9+oETJ9xwEMyPWyFnyVU+3yUPcu95C6IfuUBSMBwwAxP4ePkj6TVTd4pQVfIJl6+ztz+dQ==",
+      "dev": true,
+      "dependencies": {
+        "mathjax-modern-font": "^4.0.0-beta.5",
+        "mhchemparser": "^4.2.1",
+        "mj-context-menu": "^0.9.1",
+        "speech-rule-engine": "^4.1.0-beta.9"
+      }
+    },
+    "node_modules/mathjax-modern-font": {
+      "version": "4.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-4.0.0-beta.6.tgz",
+      "integrity": "sha512-5ZGR1yiidR/JC7XU26EyVYV0JIKvrSjHbEM+BNiMM9FyGy5Coqy0nZxPwCX42NKjYnvq8Ud/I/09couF6puU/Q==",
+      "dev": true
+    },
     "node_modules/mathml-to-latex": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.4.1.tgz",
@@ -4193,6 +4212,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
       "dev": true
     },
     "node_modules/micromatch": {
@@ -4284,6 +4309,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.1.tgz",
+      "integrity": "sha512-ECPcVXZFRfeYOxb1MWGzctAtnQcZ6nRucE3orfkKX7t/KE2mlXO2K/bq4BcCGOuhdz3Wg2BZDy2S8ECK73/iIw==",
+      "dev": true
     },
     "node_modules/mkdirp": {
       "version": "3.0.1",
@@ -5887,6 +5918,38 @@
         "os-shim": "^0.1.2"
       }
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.0-beta.10.tgz",
+      "integrity": "sha512-SPqPF4YPdqvg0+VvQKpOi68SFFMCyvGI3zNfWPJx0faxh/eHjH3ATbRu4GjoWWnHGWKY8uSqXjz/1UnFVI6NmQ==",
+      "dev": true,
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.0-beta.8",
+        "commander": "11.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/@xmldom/xmldom": {
+      "version": "0.9.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.0-beta.8.tgz",
+      "integrity": "sha512-Q5bFbYxRJKTYP7S1a0HIlumTmJRHHMGrNvBp8F1mUEyyGTeCs0g8+FKAaA6tU+YFsZgHKA0eRKzZhYdhpgAHAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -6675,6 +6738,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "dev": true
     },
     "node_modules/widest-line": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onenote2xournalpp-addon",
-  "version": "1.3.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onenote2xournalpp-addon",
-      "version": "1.3.0",
+      "version": "1.4.2",
       "license": "ISC",
       "devDependencies": {
         "@types/chrome": "^0.0.248",
@@ -15,6 +15,7 @@
         "@types/webextension-polyfill": "^0.10.7",
         "esbuild": "^0.21.5",
         "html-minifier-terser": "^7.2.0",
+        "mathml-to-latex": "^1.4.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.5.2",
         "web-ext": "^8.2.0",
@@ -1222,6 +1223,15 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -4146,6 +4156,15 @@
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "dev": true
+    },
+    "node_modules/mathml-to-latex": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.4.1.tgz",
+      "integrity": "sha512-3B+q88sVnQCqWG0UN5scYZRsUE0O2GFNfqCA0AMY/+iNkrwm3n4eiqFNKpJQ0lguHhbLfuKKoJuPixDKuqiLCQ==",
+      "dev": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.10"
+      }
     },
     "node_modules/mem": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/webextension-polyfill": "^0.10.7",
     "esbuild": "^0.21.5",
     "html-minifier-terser": "^7.2.0",
+    "mathml-to-latex": "^1.4.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.5.2",
     "web-ext": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/webextension-polyfill": "^0.10.7",
     "esbuild": "^0.21.5",
     "html-minifier-terser": "^7.2.0",
+    "mathjax-full": "4.0.0-beta.5",
     "mathml-to-latex": "^1.4.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.5.2",

--- a/public/popup.html
+++ b/public/popup.html
@@ -23,7 +23,9 @@
                         <span class="text-muted" o2x-i18n="emptyNameInfo">If empty it takes the name of the OneNote document</span>
                     </div>
                     <div class="col">
-                        <button type="button" class="btn border-color m-3" id="exportButton" o2x-i18n="exportButton">Export</button>
+                        <button type="button" class="btn border-color m-3" id="exportButton" o2x-i18n="exportButton">
+                            Export
+                        </button>
                     </div>
                 </div>
             </div>
@@ -34,15 +36,18 @@
 
                         <div class="form-checkbox">
                             <input type="checkbox" checked id="exportStrokes">
-                            <label class="checkbox-text" for="exportStrokes" o2x-i18n="exportStrokesLabel">Export strokes</label>
+                            <label class="checkbox-text" for="exportStrokes" o2x-i18n="exportStrokesLabel">Export
+                                strokes</label>
                         </div>
                         <div class="form-checkbox">
                             <input type="checkbox" checked id="exportImages">
-                            <label class="checkbox-text" for="exportImages" o2x-i18n="exportImagesLabel">Export images</label>
+                            <label class="checkbox-text" for="exportImages" o2x-i18n="exportImagesLabel">Export
+                                images</label>
                         </div>
                         <div class="form-checkbox">
                             <input type="checkbox" checked id="exportTexts">
-                            <label class="checkbox-text" for="exportTexts" o2x-i18n="exportTextsLabel">Export texts</label>
+                            <label class="checkbox-text" for="exportTexts" o2x-i18n="exportTextsLabel">Export
+                                texts</label>
                         </div>
                         <div class="form-checkbox">
                             <input type="checkbox" checked id="exportMath">
@@ -50,15 +55,16 @@
                         </div>
                         <div class="form-checkbox">
                             <input type="checkbox" checked id="exportSeparateLayers">
-                            <label class="checkbox-text" for="exportSeparateLayers" o2x-i18n="exportSeparateLayersLabel">Export in separate layers</label>
+                            <label class="checkbox-text" for="exportSeparateLayers"
+                                   o2x-i18n="exportSeparateLayersLabel">Export in separate layers</label>
                         </div>
                     </div>
                     <div class="col">
                         <div class="form-checkbox">
                             <input type="checkbox" id="exportDarkMode">
-                            <label class="checkbox-text" for="exportDarkMode" o2x-i18n="exportDarkModeLabel">Dark mode</label>
+                            <label class="checkbox-text" for="exportDarkMode" o2x-i18n="exportDarkModeLabel">Dark
+                                mode</label>
                         </div>
-
                         <!-- TODO
                         <h4>Log options: </h4>
                         <button id="openLogButton" class="btn border-color my-1">Open/Close Log</button>
@@ -69,7 +75,14 @@
 
                     </div>
                 </div>
-
+                <div class="row">
+                    <label for="mathQuality" o2x-i18n="mathQualityLabel" class="px-1">Math Export Quality</label>
+                    <select id="mathQuality">
+                        <option value="1" o2x-i18n="mathLowQuality">Low</option>
+                        <option value="2" o2x-i18n="mathMediumQuality" selected>Medium</option>
+                        <option value="4" o2x-i18n="mathHighQuality">High</option>
+                    </select>
+                </div>
             </div>
         </div>
         <!-- TODO
@@ -130,7 +143,8 @@
     </div>
     <div class="row">
         <div class="col">
-        <a href="https://github.com/nico9889/OneNote2XournalppAddon/wiki/Internationalization" target="_blank">Help with translations!</a>
+            <a href="https://github.com/nico9889/OneNote2XournalppAddon/wiki/Internationalization" target="_blank">Help
+                with translations!</a>
         </div>
     </div>
 </footer>

--- a/public/popup.html
+++ b/public/popup.html
@@ -45,6 +45,10 @@
                             <label class="checkbox-text" for="exportTexts" o2x-i18n="exportTextsLabel">Export texts</label>
                         </div>
                         <div class="form-checkbox">
+                            <input type="checkbox" checked id="exportMath">
+                            <label class="checkbox-text" for="exportMath" o2x-i18n="exportMathLabel">Export math</label>
+                        </div>
+                        <div class="form-checkbox">
                             <input type="checkbox" checked id="exportSeparateLayers">
                             <label class="checkbox-text" for="exportSeparateLayers" o2x-i18n="exportSeparateLayersLabel">Export in separate layers</label>
                         </div>

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -6,13 +6,6 @@ import {ConvertMessage} from "./messages/convert";
 
 const log = new Log();
 
-async function convert(filename: string, strokes: boolean, images: boolean, texts: boolean, maths: boolean, dark_page: boolean, strokes_dark_mode: boolean, texts_dark_mode: boolean, maths_dark_mode: boolean, separateLayers: boolean) {
-    const converter: Converter = Converter.build(log);
-    await converter.convert(strokes, images, texts, maths, separateLayers, dark_page, strokes_dark_mode, texts_dark_mode, maths_dark_mode, filename);
-    converter.download();
-}
-
-
 /* TODO
 interface LogEnableMessage extends Message {
     enable: boolean;
@@ -24,22 +17,11 @@ interface LogDebugMessage extends Message {
  */
 
 browser.runtime.onMessage.addListener(async(msg) => {
-
     const message = JSON.parse(msg.text) as (Message);
     if (message.message === 'convert') {
-        const convert_message = message as ConvertMessage;
-        await convert(
-            convert_message.filename,
-            convert_message.strokes,
-            convert_message.images,
-            convert_message.texts,
-            convert_message.maths,
-            convert_message.dark_page,
-            convert_message.strokes_dark_mode,
-            convert_message.texts_dark_mode,
-            convert_message.math_dark_mode,
-            convert_message.separateLayers,
-        );
+        const converter: Converter = Converter.build(log);
+        await converter.convert(message as ConvertMessage);
+        converter.download();
     }
 
     /* TODO

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -6,9 +6,10 @@ import {ConvertMessage} from "./messages/convert";
 
 const log = new Log();
 
-function convert(filename: string, strokes: boolean, images: boolean, texts: boolean, dark_page: boolean, strokes_dark_mode: boolean, texts_dark_mode: boolean, separateLayers: boolean) {
+async function convert(filename: string, strokes: boolean, images: boolean, texts: boolean, maths: boolean, dark_page: boolean, strokes_dark_mode: boolean, texts_dark_mode: boolean, maths_dark_mode: boolean, separateLayers: boolean) {
     const converter: Converter = Converter.build(log);
-    converter.convert(strokes, images, texts, separateLayers, dark_page, strokes_dark_mode, texts_dark_mode, filename);
+    await converter.convert(strokes, images, texts, maths, separateLayers, dark_page, strokes_dark_mode, texts_dark_mode, maths_dark_mode, filename);
+    converter.download();
 }
 
 
@@ -22,19 +23,21 @@ interface LogDebugMessage extends Message {
 }
  */
 
-browser.runtime.onMessage.addListener((msg) => {
+browser.runtime.onMessage.addListener(async(msg) => {
 
     const message = JSON.parse(msg.text) as (Message);
     if (message.message === 'convert') {
         const convert_message = message as ConvertMessage;
-        convert(
+        await convert(
             convert_message.filename,
             convert_message.strokes,
             convert_message.images,
             convert_message.texts,
+            convert_message.maths,
             convert_message.dark_page,
             convert_message.strokes_dark_mode,
             convert_message.texts_dark_mode,
+            convert_message.math_dark_mode,
             convert_message.separateLayers,
         );
     }

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -16,8 +16,8 @@ import { RegisterHTMLHandler } from 'mathjax-full/mjs/handlers/html.js'
 
 
 const image_base64_strip = new RegExp("data:image/.*;base64,");
-const adaptor = browserAdaptor()
-RegisterHTMLHandler(adaptor)
+const unsafe_xml_space = new RegExp(String.fromCharCode(160));
+
 
 export class Converter {
     private log: Log;
@@ -271,7 +271,7 @@ export class Converter {
 
                 const node = mathDocument.convert(container.innerHTML);
 
-                const blob = new Blob([adaptor.innerHTML(node)], {type: "image/svg+xml;charset=utf-8"});
+                const blob = new Blob([this.adaptor.innerHTML(node)], {type: "image/svg+xml;charset=utf-8"});
 
                 const url = URL.createObjectURL(blob);
 

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -310,7 +310,7 @@ export class Converter {
 
                 // Pushing the TexImage into the output array
                 converted_blocks.push(tex_image);
-
+                URL.revokeObjectURL(url);
             } catch (e) {
                 console.error("O2X: Error converting to SVG", e);
             }

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -288,8 +288,8 @@ export class Converter {
                 });
 
 
-                // Drawing the image into a Canvas, dimensions are multiplied by 4 to get a crispier text
-                ctx.drawImage(img, 0, 0, boundingRect.width * 4, boundingRect.height * 4);
+                // Drawing the image into a Canvas
+                ctx.drawImage(img, 0, 0, boundingRect.width, boundingRect.height);
 
                 // Exporting the Canvas as an encoded Base64 PNG string
 
@@ -302,11 +302,13 @@ export class Converter {
                     uri.replace(image_base64_strip, ""),
                     boundingRect.x - offset_x,
                     boundingRect.y - offset_y,
-                    boundingRect.width,
-                    boundingRect.height,
+                    canvas.width,
+                    canvas.height,
                 )
+
                 // Pushing the TexImage into the output array
                 converted_blocks.push(tex_image);
+
             } catch (e) {
                 console.debug("Error converting to SVG", e);
             }

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -16,7 +16,7 @@ import { RegisterHTMLHandler } from 'mathjax-full/mjs/handlers/html.js'
 
 
 const image_base64_strip = new RegExp("data:image/.*;base64,");
-const unsafe_xml_space = new RegExp(String.fromCharCode(160));
+const unsafe_xml_space = new RegExp("&nbsp;", "g");
 
 
 export class Converter {
@@ -259,7 +259,7 @@ export class Converter {
         for (const container of math_containers) {
             const math_element = container.children[0] as MathMLElement;
             const boundingRect = math_element.getBoundingClientRect();
-            const latex = MathMLToLaTeX.convert(math_element.outerHTML);
+            const latex = decodeURI(MathMLToLaTeX.convert(math_element.outerHTML)).replace(unsafe_xml_space, " ");
 
             try {
                 const mathDocument = mathjax.document('', {

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -256,19 +256,19 @@ export class Converter {
         // Preparing canvas for image conversion
         const canvas = document.createElement("canvas") as HTMLCanvasElement;
         const ctx = canvas.getContext("2d")!;
+        const mathDocument = mathjax.document('', {
+            InputJax: new MathML(),
+            OutputJax: new SVG({
+                scale: 4.0,
+                mathmlSpacing: true
+            })
+        });
         for (const container of math_containers) {
             const math_element = container.children[0] as MathMLElement;
             const boundingRect = math_element.getBoundingClientRect();
             const latex = decodeURI(MathMLToLaTeX.convert(math_element.outerHTML)).replace(unsafe_xml_space, " ");
 
             try {
-                const mathDocument = mathjax.document('', {
-                    InputJax: new MathML(),
-                    OutputJax: new SVG({
-                        mathmlSpacing: true
-                    })
-                });
-
                 const node = mathDocument.convert(container.innerHTML);
 
                 const blob = new Blob([this.adaptor.innerHTML(node)], {type: "image/svg+xml;charset=utf-8"});
@@ -292,7 +292,6 @@ export class Converter {
                 ctx.drawImage(img, 0, 0, boundingRect.width, boundingRect.height);
 
                 // Exporting the Canvas as an encoded Base64 PNG string
-
                 const uri = canvas.toDataURL("image/png", 1);
 
                 // Clearing the Canvas

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -264,10 +264,13 @@ export class Converter {
             try {
                 const mathDocument = mathjax.document('', {
                     InputJax: new MathML(),
-                    OutputJax: new SVG({ fontCache: 'local' })
+                    OutputJax: new SVG({
+                        mathmlSpacing: true
+                    })
                 });
 
                 const node = mathDocument.convert(container.innerHTML);
+
                 const blob = new Blob([adaptor.innerHTML(node)], {type: "image/svg+xml;charset=utf-8"});
 
                 const url = URL.createObjectURL(blob);

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -312,7 +312,7 @@ export class Converter {
                 converted_blocks.push(tex_image);
 
             } catch (e) {
-                console.debug("Error converting to SVG", e);
+                console.error("O2X: Error converting to SVG", e);
             }
 
             if (additional) {

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -11,17 +11,17 @@ import {MathMLToLaTeX} from 'mathml-to-latex';
 import { mathjax } from 'mathjax-full/mjs/mathjax.js'
 import { MathML} from 'mathjax-full/mjs/input/mathml.js'
 import { SVG } from 'mathjax-full/mjs/output/svg.js'
-import { liteAdaptor } from 'mathjax-full/mjs/adaptors/liteAdaptor.js'
+import { browserAdaptor } from 'mathjax-full/mjs/adaptors/browserAdaptor.js'
 import { RegisterHTMLHandler } from 'mathjax-full/mjs/handlers/html.js'
 
 
 const image_base64_strip = new RegExp("data:image/.*;base64,");
-const adaptor = liteAdaptor()
+const adaptor = browserAdaptor()
 RegisterHTMLHandler(adaptor)
 
 export class Converter {
     private log: Log;
-    adaptor = liteAdaptor();
+    adaptor = browserAdaptor();
     // Stroke need to be scaled to this size
     scaleX: number = 0.04;
     scaleY: number = 0.04;

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -295,6 +295,9 @@ export class Converter {
 
                 const uri = canvas.toDataURL("image/png", 1);
 
+                // Clearing the Canvas
+                ctx.clearRect(0,0, canvas.width, canvas.height);
+
                 // Creating a new TexImage with dimensions and data, this object handles
                 // the XML conversion
                 const tex_image = new TexImage(

--- a/src/messages/convert.ts
+++ b/src/messages/convert.ts
@@ -5,9 +5,11 @@ export interface ConvertMessage extends Message {
     filename: string,
     images: boolean,
     texts: boolean,
+    maths: boolean,
     strokes: boolean,
     separateLayers: boolean,
     dark_page: boolean,
     strokes_dark_mode: boolean,
     texts_dark_mode: boolean,
+    math_dark_mode: boolean
 }

--- a/src/messages/convert.ts
+++ b/src/messages/convert.ts
@@ -1,5 +1,10 @@
 import {Message} from "./index";
 
+export enum MathQuality{
+    Low=1,
+    Medium=2,
+    High=4
+}
 
 export interface ConvertMessage extends Message {
     filename: string,
@@ -12,4 +17,5 @@ export interface ConvertMessage extends Message {
     strokes_dark_mode: boolean,
     texts_dark_mode: boolean,
     math_dark_mode: boolean
+    math_quality: MathQuality
 }

--- a/src/onenote2xournalpp.ts
+++ b/src/onenote2xournalpp.ts
@@ -19,6 +19,7 @@ const exportMaths: HTMLInputElement = document.getElementById("exportMath") as (
 const exportSeparateLayers: HTMLInputElement = document.getElementById("exportSeparateLayers") as (HTMLInputElement);
 const exportDarkMode: HTMLInputElement = document.getElementById("exportDarkMode") as (HTMLInputElement);
 const container: HTMLInputElement = document.getElementById('container') as HTMLInputElement;
+const mathQuality: HTMLSelectElement = document.getElementById("mathQuality") as HTMLSelectElement;
 
 /* TODO
 const log = document.getElementById('log');
@@ -28,7 +29,7 @@ const enableDebugButton = document.getElementById('enableDebugButton');
 */
 
 type Settings = {
-    [K in SettingsKeys]: boolean
+    [K in SettingsKeys]: boolean | number
 }
 
 type SettingsKeys =
@@ -40,7 +41,8 @@ type SettingsKeys =
     | "export_dark_page"
     | "export_strokes_dark_mode"
     | "export_maths_dark_mode"
-    | "export_texts_dark_mode";
+    | "export_texts_dark_mode"
+    | "math_export_quality";
 
 let settings: Settings = {
     export_images: exportImages?.checked || true,
@@ -51,7 +53,8 @@ let settings: Settings = {
     export_dark_page: exportDarkMode?.checked || false,
     export_strokes_dark_mode: exportDarkMode?.checked || false,
     export_maths_dark_mode: exportDarkMode?.checked || false,
-    export_texts_dark_mode: exportDarkMode?.checked || false
+    export_texts_dark_mode: exportDarkMode?.checked || false,
+    math_export_quality: 2
 };
 
 
@@ -80,13 +83,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         settings = items["o2x-settings"];
     }
 
-    exportImages.checked = settings.export_images;
-    exportStrokes.checked = settings.export_strokes;
-    exportTexts.checked = settings.export_texts;
-    exportMaths.checked = settings.export_maths;
-    exportSeparateLayers.checked = settings.export_separate_layers;
-    exportDarkMode.checked = settings.export_dark_page;
-
+    exportImages.checked = Boolean(settings.export_images);
+    exportStrokes.checked = Boolean(settings.export_strokes);
+    exportTexts.checked = Boolean(settings.export_texts);
+    exportMaths.checked = Boolean(settings.export_maths);
+    exportSeparateLayers.checked = Boolean(settings.export_separate_layers);
+    exportDarkMode.checked = Boolean(settings.export_dark_page);
+    mathQuality.value = String(settings.math_export_quality);
 
     /* TODO
     const item = await browser.storage.local.get(['o2x-log-debug', 'o2x-log-show']);
@@ -113,6 +116,13 @@ function setUpdateSettingsListener(input: HTMLInputElement, settings_key: Settin
     });
 }
 
+function setUpdateSettingsSelectListener(input: HTMLSelectElement, settings_key: SettingsKeys) {
+    input.addEventListener("change", async () => {
+        settings[settings_key] = Number(input.value);
+        await browser.storage.local.set({"o2x-settings": settings});
+    });
+}
+
 setUpdateSettingsListener(exportImages, "export_images");
 setUpdateSettingsListener(exportStrokes, "export_strokes");
 setUpdateSettingsListener(exportSeparateLayers, "export_separate_layers");
@@ -121,6 +131,7 @@ setUpdateSettingsListener(exportMaths, "export_maths");
 setUpdateSettingsListener(exportDarkMode, "export_dark_page");
 setUpdateSettingsListener(exportDarkMode, "export_strokes_dark_mode");
 setUpdateSettingsListener(exportDarkMode, "export_texts_dark_mode");
+setUpdateSettingsSelectListener(mathQuality, "math_export_quality");
 
 
 /* TODO
@@ -225,7 +236,7 @@ exportButton?.addEventListener('click', async () => {
             texts: exportTexts?.checked ?? true,
             maths: exportMaths?.checked ?? true,
             strokes: exportStrokes?.checked ?? true,
-
+            math_quality: Number(mathQuality.value) ?? 2,
             separateLayers: exportSeparateLayers?.checked ?? true
         }
         await browser.tabs.sendMessage(tab?.id ?? 0, {

--- a/src/onenote2xournalpp.ts
+++ b/src/onenote2xournalpp.ts
@@ -15,6 +15,7 @@ const fileNameInput: HTMLInputElement = document.getElementById("fileName") as (
 const exportImages: HTMLInputElement = document.getElementById("exportImages") as (HTMLInputElement);
 const exportTexts: HTMLInputElement = document.getElementById("exportTexts") as (HTMLInputElement);
 const exportStrokes: HTMLInputElement = document.getElementById("exportStrokes") as (HTMLInputElement);
+const exportMaths: HTMLInputElement = document.getElementById("exportMath") as (HTMLInputElement);
 const exportSeparateLayers: HTMLInputElement = document.getElementById("exportSeparateLayers") as (HTMLInputElement);
 const exportDarkMode: HTMLInputElement = document.getElementById("exportDarkMode") as (HTMLInputElement);
 const container: HTMLInputElement = document.getElementById('container') as HTMLInputElement;
@@ -34,18 +35,22 @@ type SettingsKeys =
     "export_images"
     | "export_texts"
     | "export_strokes"
+    | "export_maths"
     | "export_separate_layers"
     | "export_dark_page"
     | "export_strokes_dark_mode"
+    | "export_maths_dark_mode"
     | "export_texts_dark_mode";
 
 let settings: Settings = {
     export_images: exportImages?.checked || true,
     export_texts: exportTexts?.checked || true,
     export_strokes: exportStrokes?.checked || true,
+    export_maths: exportMaths?.checked || true,
     export_separate_layers: exportSeparateLayers?.checked || true,
     export_dark_page: exportDarkMode?.checked || false,
     export_strokes_dark_mode: exportDarkMode?.checked || false,
+    export_maths_dark_mode: exportDarkMode?.checked || false,
     export_texts_dark_mode: exportDarkMode?.checked || false
 };
 
@@ -78,6 +83,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     exportImages.checked = settings.export_images;
     exportStrokes.checked = settings.export_strokes;
     exportTexts.checked = settings.export_texts;
+    exportMaths.checked = settings.export_maths;
     exportSeparateLayers.checked = settings.export_separate_layers;
     exportDarkMode.checked = settings.export_dark_page;
 
@@ -111,6 +117,7 @@ setUpdateSettingsListener(exportImages, "export_images");
 setUpdateSettingsListener(exportStrokes, "export_strokes");
 setUpdateSettingsListener(exportSeparateLayers, "export_separate_layers");
 setUpdateSettingsListener(exportTexts, "export_texts");
+setUpdateSettingsListener(exportMaths, "export_maths");
 setUpdateSettingsListener(exportDarkMode, "export_dark_page");
 setUpdateSettingsListener(exportDarkMode, "export_strokes_dark_mode");
 setUpdateSettingsListener(exportDarkMode, "export_texts_dark_mode");
@@ -211,10 +218,12 @@ exportButton?.addEventListener('click', async () => {
             dark_page: exportDarkMode?.checked ?? false,
             strokes_dark_mode: exportDarkMode?.checked ?? false,
             texts_dark_mode: exportDarkMode?.checked ?? false,
+            math_dark_mode: exportDarkMode?.checked ?? false,
             message: 'convert',
             filename: fileNameInput?.value || "",
             images: exportImages?.checked ?? true,
             texts: exportTexts?.checked ?? true,
+            maths: exportMaths?.checked ?? true,
             strokes: exportStrokes?.checked ?? true,
 
             separateLayers: exportSeparateLayers?.checked ?? true

--- a/src/xournalpp/page.ts
+++ b/src/xournalpp/page.ts
@@ -2,6 +2,7 @@ import {Image} from "./image";
 import {Text} from "./text";
 import {Stroke} from "./stroke";
 import {Color, RGBAColor} from "./utils";
+import {TexImage} from "./teximage";
 
 export enum BackgroundType{
     Solid = "solid"
@@ -32,6 +33,7 @@ export class Layer{
     texts: Text[] = [];
     images: Image[] = [];
     strokes: Stroke[] = [];
+    maths: TexImage[] = [];
 
     constructor() {
     }
@@ -45,6 +47,9 @@ export class Layer{
             out += `${text.toXml()}\n`;
         }
         for(const image of this.images){
+            out += `${image.toXml()}\n`;
+        }
+        for(const image of this.maths){
             out += `${image.toXml()}\n`;
         }
         out += "</layer>";

--- a/src/xournalpp/teximage.ts
+++ b/src/xournalpp/teximage.ts
@@ -15,6 +15,6 @@ export class TexImage extends Image{
     }
 
     toXml(){
-        return (this.data) ? `<image text="${this.text}" left="${this.left.toFixed(4)}" right="${this.right.toFixed(4)}" top="${this.top.toFixed(4)}" bottom="${this.bottom.toFixed(4)}">${this.data}</image>`: "";
+        return (this.data) ? `<teximage text="${this.text}" left="${this.left.toFixed(4)}" right="${this.right.toFixed(4)}" top="${this.top.toFixed(4)}" bottom="${this.bottom.toFixed(4)}">${this.data}</teximage>`: "";
     }
 }

--- a/src/xournalpp/teximage.ts
+++ b/src/xournalpp/teximage.ts
@@ -1,0 +1,20 @@
+import {Image} from "./image";
+
+// Xournal++ renders math block in a very quirky way:
+// it converts the Tex equation into a base64 encoded PDF binary, and then it renders it.
+// The original equation is saved inside the `text` tag for later edit.
+// Somehow the Xournal++ renderer seems to be able to distinguish PDF binary from PNG binary,
+// and it's able to render correctly the TexImage block even if it's content it's replaced with PNG.
+export class TexImage extends Image{
+    // Equation in Tex format
+    text: string;
+
+    constructor(text: string, data: string, x: number, y: number, width: number, height: number) {
+        super(data, x, y, width, height);
+        this.text = text;
+    }
+
+    toXml(){
+        return (this.data) ? `<image text="${this.text}" left="${this.left.toFixed(4)}" right="${this.right.toFixed(4)}" top="${this.top.toFixed(4)}" bottom="${this.bottom.toFixed(4)}">${this.data}</image>`: "";
+    }
+}


### PR DESCRIPTION
Adds supports for OneNote Math blocks:
* Blocks are converted into Xournal++ `<teximage>`;
  * MathML is converted into LaTeX for later editing into Xournal++;
  * MathML is rendered as `PNG` for embedding into the `.xopp` file.

Math blocks can be rendered at different resolution, hardcoded presets are:
* original resolution (blurry but readable, lowest file size);
* 2x resolution (default option, less blurry);
* 4x resolution (very high resolution text but it has "high" impact in file size).

Unfortunately this required two additional libraries which increased the final bundle size significantly (~20x increase).
Most of the size comes from fonts imported by MathJax and are probably unused.

Closes #7 