### PR TITLE
feat: zoom and scroll handling

### DIFF
--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -105,8 +105,8 @@ export async function convertNote(message: ConvertMessage): Promise<Downloadable
     }
     const panel_boundaries = panel.getBoundingClientRect();
     const offsets = {
-        x: panel_boundaries.x,
-        y: panel_boundaries.y
+        x: panel_boundaries.x - panel.scrollLeft,
+        y: panel_boundaries.y - panel.scrollTop
     }
 
     const zoom_level = getZoomLevel();

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -47,6 +47,22 @@ function getTitle() {
     return page.innerText;
 }
 
+function getZoomLevel() {
+    const origin = document.getElementsByClassName("PageContentOrigin")[0];
+    if (!origin) {
+        return 1.0;
+    }
+    const style = origin.getAttribute("style");
+    if (!style) {
+        return 1.0;
+    }
+    const matches = style.match("scale\\(([0-9]+\.?[0-9]*)\\)");
+    if (!matches) {
+        return 1.0;
+    }
+    return Number.parseFloat(matches[1] ?? "1.0");
+}
+
 export async function convertNote(message: ConvertMessage): Promise<DownloadableDocument> {
     let title = message.filename;
     const strokes = message.strokes;
@@ -93,11 +109,12 @@ export async function convertNote(message: ConvertMessage): Promise<Downloadable
         y: panel_boundaries.y
     }
 
-    const converted_texts: Text[] = (texts) ? convertTexts(offsets, texts_dark_mode, page_size) : [];
-    const converted_images: Image[] = (images) ? convertImages(offsets, page_size) : [];
-    const converted_strokes: Stroke[] = (strokes) ? convertStrokes(strokes_dark_mode, page_size) : [];
-    const converted_math_blocks: TexImage[] = (maths) ? (await convertMathMLBlocks(offsets, math_dark_mode, math_quality, page_size)) : [];
+    const zoom_level = getZoomLevel();
 
+    const converted_texts: Text[] = (texts) ? convertTexts(offsets, texts_dark_mode, page_size, zoom_level) : [];
+    const converted_images: Image[] = (images) ? convertImages(offsets, page_size, zoom_level) : [];
+    const converted_strokes: Stroke[] = (strokes) ? convertStrokes(strokes_dark_mode, page_size, zoom_level) : [];
+    const converted_math_blocks: TexImage[] = (maths) ? (await convertMathMLBlocks(offsets, math_dark_mode, math_quality, page_size, zoom_level)) : [];
 
     // Creates a new Xournal++ document
     LOG.info("Creating new XOPP file");

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -56,7 +56,7 @@ function getZoomLevel() {
     if (!style) {
         return 1.0;
     }
-    const matches = style.match("scale\\(([0-9]+\.?[0-9]*)\\)");
+    const matches = style.match("scale\\(([0-9]+\\.?[0-9]*)\\)");
     if (!matches) {
         return 1.0;
     }

--- a/src/converter/elements/images.ts
+++ b/src/converter/elements/images.ts
@@ -50,8 +50,8 @@ export function convertImages(offsets: Offsets, page_size: PageSize, zoom_level:
 
         // Inelegant solution to export images max_width and max_height by side effect without
         // scanning multiple times all the images
-        page_size.width = Math.max(page_size.width, converted_image.right / zoom_level);
-        page_size.height = Math.max(page_size.height, image_boundaries.bottom / zoom_level);
+        page_size.width = Math.max(page_size.width, converted_image.right);
+        page_size.height = Math.max(page_size.height, converted_image.bottom);
     }
     return converted_images
 }

--- a/src/converter/elements/images.ts
+++ b/src/converter/elements/images.ts
@@ -4,7 +4,7 @@ import {LOG, Offsets, PageSize} from "../converter";
 export const IMAGE_BASE64_REGEXP = new RegExp("data:image/.*;base64,");
 
 
-export function convertImages(offsets: Offsets, page_size: PageSize) {
+export function convertImages(offsets: Offsets, page_size: PageSize, zoom_level: number) {
     LOG.info("Converting images");
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
@@ -36,16 +36,22 @@ export function convertImages(offsets: Offsets, page_size: PageSize) {
 
         const data = src.replace(IMAGE_BASE64_REGEXP, "");
 
-        const converted_image = new Image(data, x || (image_boundaries.x - offsets.x), y || (image_boundaries.y - offsets.y), image.width, image.height);
+        const real_x = (x || ((image_boundaries.x - offsets.x) / zoom_level));
+        const real_y = (y || ((image_boundaries.y - offsets.y) / zoom_level));
+
+        const converted_image = new Image(
+            data,
+            real_x,
+            real_y,
+            image.width,
+            image.height
+        );
         converted_images.push(converted_image);
 
         // Inelegant solution to export images max_width and max_height by side effect without
         // scanning multiple times all the images
-        if (page_size) {
-            page_size.width = Math.max(page_size.width, converted_image.right);
-            page_size.height = Math.max(page_size.height, image_boundaries.bottom);
-        }
-
+        page_size.width = Math.max(page_size.width, converted_image.right / zoom_level);
+        page_size.height = Math.max(page_size.height, image_boundaries.bottom / zoom_level);
     }
     return converted_images
 }

--- a/src/converter/elements/math.ts
+++ b/src/converter/elements/math.ts
@@ -65,14 +65,14 @@ export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: bool
                 img.src = url;
             });
             // Setting output image resolution scale based on user preferences (x1, x2, x4)
-            canvas.width = img.width * math_quality * zoom_level;
-            canvas.height = img.height * math_quality * zoom_level;
+            canvas.width = img.width * math_quality ;
+            canvas.height = img.height * math_quality ;
 
             // Drawing the image into a Canvas
             if(math_dark_mode) {
                 ctx.filter = 'invert(100%)';
             }
-            ctx.drawImage(img, 0, 0, boundingRect.width * math_quality, boundingRect.height * math_quality);
+            ctx.drawImage(img, 0, 0, boundingRect.width * math_quality / zoom_level, boundingRect.height * math_quality / zoom_level);
 
             // Exporting the Canvas as an encoded Base64 PNG string
             const uri = canvas.toDataURL("image/png", 1);

--- a/src/converter/elements/math.ts
+++ b/src/converter/elements/math.ts
@@ -20,7 +20,7 @@ function sanitize_latex(latex: string): string{
 const ADAPTOR = browserAdaptor();
 RegisterHTMLHandler(ADAPTOR);
 
-export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: boolean, math_quality: MathQuality, page_size: PageSize) {
+export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: boolean, math_quality: MathQuality, page_size: PageSize, zoom_level: number) {
     LOG.info("Converting MathML blocks");
     const converted_blocks: TexImage[] = [] // Empty output array
 
@@ -65,8 +65,8 @@ export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: bool
                 img.src = url;
             });
             // Setting output image resolution scale based on user preferences (x1, x2, x4)
-            canvas.width = img.width * math_quality;
-            canvas.height = img.height * math_quality;
+            canvas.width = img.width * math_quality * zoom_level;
+            canvas.height = img.height * math_quality * zoom_level;
 
             // Drawing the image into a Canvas
             if(math_dark_mode) {
@@ -85,16 +85,14 @@ export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: bool
             const tex_image = new TexImage(
                 latex,
                 uri.replace(IMAGE_BASE64_REGEXP, ""),
-                boundingRect.x - offsets.x,
-                boundingRect.y - offsets.y - (fontSize / 2),
+                (boundingRect.x - offsets.x) / zoom_level,
+                (boundingRect.y - offsets.y - (fontSize / 2)) / zoom_level,
                 img.width,
                 img.height,
             )
 
-            if (page_size) {
-                page_size.width = Math.max(page_size.width, boundingRect.x + img.width);
-                page_size.height = Math.max(page_size.height, boundingRect.y + img.height);
-            }
+            page_size.width = Math.max(page_size.width, (boundingRect.x + img.width)  / zoom_level);
+            page_size.height = Math.max(page_size.height, (boundingRect.y + img.height)  / zoom_level);
 
             // Pushing the TexImage into the output array
             converted_blocks.push(tex_image);

--- a/src/converter/elements/math.ts
+++ b/src/converter/elements/math.ts
@@ -91,8 +91,8 @@ export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: bool
                 img.height,
             )
 
-            page_size.width = Math.max(page_size.width, (boundingRect.x + img.width)  / zoom_level);
-            page_size.height = Math.max(page_size.height, (boundingRect.y + img.height)  / zoom_level);
+            page_size.width = Math.max(page_size.width, tex_image.right);
+            page_size.height = Math.max(page_size.height, tex_image.bottom);
 
             // Pushing the TexImage into the output array
             converted_blocks.push(tex_image);

--- a/src/converter/elements/math.ts
+++ b/src/converter/elements/math.ts
@@ -86,7 +86,7 @@ export async function convertMathMLBlocks(offsets: Offsets, math_dark_mode: bool
                 latex,
                 uri.replace(IMAGE_BASE64_REGEXP, ""),
                 (boundingRect.x - offsets.x) / zoom_level,
-                (boundingRect.y - offsets.y - (fontSize / 2)) / zoom_level,
+                (boundingRect.y - offsets.y) / zoom_level - (fontSize / 2),
                 img.width,
                 img.height,
             )

--- a/src/converter/elements/strokes.ts
+++ b/src/converter/elements/strokes.ts
@@ -53,8 +53,6 @@ export function convertStrokes(dark_mode: boolean, page_size: PageSize, zoom_lev
                 // Xournal strokes representation doesn't permit empty spaces/skips, so we need to split the SVG Path into
                 // multiple strokes in case of movements
                 if (directive === "M") {
-                    // Inelegant solution to export strokes max_width and max_height by side effect without
-                    // scanning multiple times all the strokes
                     stroke = new Stroke();
                     stroke.width = width;
                     stroke.color = color;
@@ -82,8 +80,11 @@ export function convertStrokes(dark_mode: boolean, page_size: PageSize, zoom_lev
                         const next_x = old_coords[0] + (x * SCALE_X);
                         const next_y = old_coords[1] + (y * SCALE_Y);
 
+                        // Inelegant solution to export strokes max_width and max_height by side effect without
+                        // scanning multiple times all the strokes
                         page_size.width = Math.max(page_size.width, next_x);
                         page_size.height = Math.max(page_size.height, next_y);
+
                         stroke.coords.push([next_x, next_y]);
                         x = parseInt(directives[i]);
                         y = parseInt(directives[i + 1]);

--- a/src/converter/elements/strokes.ts
+++ b/src/converter/elements/strokes.ts
@@ -54,7 +54,7 @@ export function convertStrokes(dark_mode: boolean, page_size: PageSize): Stroke[
             const color = (colors) ? new RGBAColor(Number(colors[1]), Number(colors[2]), Number(colors[3]), Math.round(opacity * 255)) : base_color;
 
             // OneNote stroke width, rounded to 2 decimal positions, defaults to 1 if not found
-            const width = Math.round(Number(path.getAttribute("stroke-width")) * STROKE_SCALE * 100) / 100 ?? 1;
+            const width = Math.round(Number(path.getAttribute("stroke-width")) * STROKE_SCALE * 100) / 100;
 
 
             for (let i = 0; i < directives.length; i++) {

--- a/src/converter/elements/texts.ts
+++ b/src/converter/elements/texts.ts
@@ -4,7 +4,7 @@ import {Color, RGBAColor} from "../../xournalpp/utils";
 
 
 
-export function convertTexts(offsets: Offsets, dark_mode: boolean, page_size: PageSize){
+export function convertTexts(offsets: Offsets, dark_mode: boolean, page_size: PageSize, zoom_level: number): Text[] {
     LOG.info("Converting texts");
     const texts = document.getElementsByClassName("TextRun") as HTMLCollectionOf<HTMLSpanElement>;
     const converted_texts: Text[] = [];
@@ -41,19 +41,18 @@ export function convertTexts(offsets: Offsets, dark_mode: boolean, page_size: Pa
                     converted_text.color = new RGBAColor(Number(r), Number(g), Number(b));
             }
 
-            converted_text.x = textBoundaries.x - offsets.x;
-            converted_text.y = textBoundaries.y - offsets.y;
-            converted_text.width = textBoundaries.width;
+            converted_text.x = (textBoundaries.x - offsets.x) / zoom_level;
+            converted_text.y = (textBoundaries.y - offsets.y) / zoom_level;
 
+            // FIXME: zoom_level * 0.8 resulted out from trial&error, it may be wrong...
+            converted_text.width = (textBoundaries.width) / (zoom_level * 0.8);
 
             converted_texts.push(converted_text);
 
             // Inelegant solution to export texts max_width and max_height by side effect without
             // scanning multiple times all the texts
-            if (page_size) {
-                page_size.width = Math.max(page_size.width, converted_text.x + textBoundaries.width);
-                page_size.height = Math.max(page_size.height, converted_text.y + textBoundaries.height);
-            }
+            page_size.width = Math.max(page_size.width, converted_text.x + converted_text.width) ;
+            page_size.height = Math.max(page_size.height, converted_text.y + (textBoundaries.height / zoom_level));
 
         }
     }

--- a/src/xournalpp/stroke.ts
+++ b/src/xournalpp/stroke.ts
@@ -1,12 +1,12 @@
 import {Color, RGBAColor} from "./utils";
 
-export enum Tool{
+export enum Tool {
     Pen = "pen",
     Eraser = "eraser",
     Highlighter = "highlighter"
 }
 
-export class Stroke{
+export class Stroke {
     coords: [number, number][] = [];
     color: Color | RGBAColor = Color.Black;
     width: number = 1;
@@ -18,7 +18,7 @@ export class Stroke{
 
     toXml() {
         let out = `<stroke tool="${this.tool}" color="${this.color.toString()}" width="${this.width}">\n`
-        for(const [x,y] of this.coords){
+        for (const [x, y] of this.coords) {
             out += `${x.toFixed(4)} ${y.toFixed(4)} `;
         }
         out += "\n</stroke>";


### PR DESCRIPTION
Now the add-on can export the Xournal++ note correctly independently from the zoom percentage and the scroll position.

close #17 